### PR TITLE
#9 : 어드민 API Authorization 값 추가 

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature Report
+description: Request new Feature
+title: "[FEATURE]: "
+labels: ["🌱기능🌱"]
+body:
+  - type: textarea
+    id: new-feature
+    attributes:
+      label: 작업 사항 
+      description: 어떤 기능을 추가할건가요? 
+      placeholder: Splash API를 활용한 스플래쉬 화면 구현 
+    validations:
+      required: true
+
+  - type: textarea
+    id: todo
+    attributes:
+      label: Todo
+      description: 작업사항을 나누어 작성해주세요! 
+      value: |
+        - [ ] todo1
+
+  - type: textarea
+    id: etc
+    attributes:
+      label: 기타사항
+      description: 추가로 기록이 필요한 경우 작성해주세요!
+      placeholder: Splash API - Android Ver 12 이상부터 가능하다.

--- a/composeApp/src/commonMain/kotlin/com/wespot/staff/vote/write/add/QuestionAddViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/wespot/staff/vote/write/add/QuestionAddViewModel.kt
@@ -62,11 +62,18 @@ class QuestionAddViewModel(
                 .map { it.trim() }
             repository.postVoteQuestions(questionList)
                 .onSuccess {
+                    clearState()
                     _uiEvent.send(QuestionAddUiEvent.NavigateToQuestionScreen)
                 }
                 .onFailure { exception ->
                     _uiEvent.send(QuestionAddUiEvent.ShowToast("${exception.message} 문제가 발생했어요."))
                 }
+        }
+    }
+
+    private fun clearState() {
+        _uiState.update {
+            it.copy(questionList = listOf())
         }
     }
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -12,6 +12,7 @@ properties.load(rootProject.file("local.properties").inputStream())
 
 buildConfig {
     buildConfigField<String>("BASE_URL", properties.getProperty("BASE_URL"))
+    buildConfigField<String>("API_AUTHORIZATION_VALUE", properties.getProperty("API_AUTHORIZATION_VALUE"))
 }
 
 kotlin {

--- a/data/src/commonMain/kotlin/com/wespot/staff/data/core/DefaultKtorConfig.kt
+++ b/data/src/commonMain/kotlin/com/wespot/staff/data/core/DefaultKtorConfig.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.json.Json
 public fun HttpClientConfig<*>.defaultKtorConfig() {
     defaultRequest {
         header(HttpHeaders.ContentType, ContentType.Application.Json)
+        header(HttpHeaders.Authorization, BuildConfig.API_AUTHORIZATION_VALUE)
         url(BuildConfig.BASE_URL)
     }
 

--- a/data/src/commonMain/kotlin/com/wespot/staff/data/vote/remote/VoteApiClient.kt
+++ b/data/src/commonMain/kotlin/com/wespot/staff/data/vote/remote/VoteApiClient.kt
@@ -38,7 +38,7 @@ public class DefaultVoteApiClient(
     override suspend fun postVoteQuestions(questions: List<VoteQuestionRequest>): Result<Unit> =
         httpClient.safeRequest {
             url {
-                path("/admin/vote-options/bulk")
+                path("/admin/vote-options/bulks")
                 setBody(questions)
             }
             method = HttpMethod.Post


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#9 어드민 API 요청시, 헤더에 암호화 값 추가 

## 2. 🔥 변경된 점
- 어드민 API에서 암호화 값이 추가되었습니다.
- 이슈 템플릿이 추가되었습니다.
- 벌크 API path 수정 
- 이슈 작성 완료시 상태 초기화 

## 3. ✅ 필수 체크 사항 

## 4. 📸 작업물 사진 공유(선택)

## 5. 💡알게된 혹은 궁금한 사항
