### PR TITLE
#20 : RemoteConfig 수정 / 삭제 / 조회 구현 

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -21,6 +21,8 @@ kotlin {
             implementation(libs.kotlinx.datetime)
             implementation(libs.androidx.lifecycle.runtime.compose)
             implementation(libs.androidx.lifecycle.viewmodel)
+
+            implementation(libs.decompose)
         }
     }
 }

--- a/common/src/commonMain/kotlin/com/wespot/staff/common/base/BaseViewModel.kt
+++ b/common/src/commonMain/kotlin/com/wespot/staff/common/base/BaseViewModel.kt
@@ -1,12 +1,14 @@
 package com.wespot.staff.common.base
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 abstract class BaseViewModel<State, SideEffect> : ViewModel() {
     private val initialState: State by lazy { createInitialState() }
@@ -27,7 +29,9 @@ abstract class BaseViewModel<State, SideEffect> : ViewModel() {
         _uiState.update(action)
     }
 
-    protected suspend fun postSideEffect(sideEffect: SideEffect) {
-        _sideEffect.emit(sideEffect)
+    protected fun postSideEffect(sideEffect: SideEffect) {
+        viewModelScope.launch {
+            _sideEffect.emit(sideEffect)
+        }
     }
 }

--- a/common/src/commonMain/kotlin/com/wespot/staff/common/extensions/NavigationExt.kt
+++ b/common/src/commonMain/kotlin/com/wespot/staff/common/extensions/NavigationExt.kt
@@ -1,0 +1,13 @@
+package com.wespot.staff.common.extensions
+
+import com.arkivanov.decompose.router.stack.StackNavigation
+import com.arkivanov.decompose.router.stack.pushNew
+import com.arkivanov.decompose.router.stack.pushToFront
+
+fun <T : Any> StackNavigation<T>.navigate(configuration: T) {
+    runCatching {
+        this.pushNew(configuration)
+    }.onFailure {
+        this.pushToFront(configuration)
+    }
+}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -54,8 +54,8 @@ android {
 
     defaultConfig {
         applicationId = "com.wespot.staff"
-        versionCode = 5
-        versionName = "1.1.3"
+        versionCode = 6
+        versionName = "1.2.0"
     }
     packaging {
         resources {

--- a/composeApp/src/commonMain/kotlin/com/wespot/staff/di/ViewModelModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/wespot/staff/di/ViewModelModule.kt
@@ -4,6 +4,7 @@ import com.wespot.staff.vote.question.QuestionViewModel
 import com.wespot.staff.vote.write.add.QuestionAddViewModel
 import com.wespot.staff.RootViewModel
 import com.wespot.staff.entire.configuration.ConfigurationViewModel
+import com.wespot.staff.entire.configuration.add.ConfigurationAddViewModel
 import com.wespot.staff.entire.notification.NotificationViewModel
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModelOf
@@ -13,6 +14,7 @@ val viewModelModule: Module = module {
     viewModelOf(::QuestionViewModel)
     viewModelOf(::QuestionAddViewModel)
     viewModelOf(::ConfigurationViewModel)
+    viewModelOf(::ConfigurationAddViewModel)
     viewModelOf(::NotificationViewModel)
     viewModelOf(::RootViewModel)
 }

--- a/data/src/commonMain/kotlin/com/wespot/staff/data/config/DefaultRemoteConfigRepository.kt
+++ b/data/src/commonMain/kotlin/com/wespot/staff/data/config/DefaultRemoteConfigRepository.kt
@@ -1,5 +1,6 @@
 package com.wespot.staff.data.config
 
+import com.wespot.staff.data.config.model.RemoteConfigDto
 import com.wespot.staff.data.config.remote.RemoteConfigDataSource
 import com.wespot.staff.domain.config.RemoteConfig
 import com.wespot.staff.domain.config.RemoteConfigKey
@@ -21,6 +22,27 @@ class DefaultRemoteConfigRepository(
                     value = entry.value.asString(),
                 )
             }
+
+    override suspend fun getRemoteConfigValue(): Result<List<RemoteConfig>> =
+        dataSource.getRemoteConfigValue()
+            .mapCatching { remoteConfigList ->
+                remoteConfigList.map {
+                    RemoteConfig(
+                        key = it.key,
+                        description = getRemoteConfigDescription(it.key),
+                        value = it.value,
+                    )
+                }
+            }
+
+    override suspend fun postRemoteConfigValue(remoteConfig: RemoteConfig): Result<Unit> =
+        dataSource.postRemoteConfigValue(remoteConfig = RemoteConfigDto(remoteConfig.key, remoteConfig.value))
+
+    override suspend fun putRemoteConfigValue(remoteConfig: RemoteConfig): Result<Unit> =
+        dataSource.putRemoteConfigValue(remoteConfig = RemoteConfigDto(remoteConfig.key, remoteConfig.value))
+
+    override suspend fun deleteRemoteConfigValue(key: String): Result<Unit> =
+        dataSource.deleteRemoteConfigValue(key)
 
     private fun getRemoteConfigDescription(key: String) = runCatching {
         RemoteConfigKey.valueOf(key).toDescription()

--- a/data/src/commonMain/kotlin/com/wespot/staff/data/config/model/RemoteConfigDto.kt
+++ b/data/src/commonMain/kotlin/com/wespot/staff/data/config/model/RemoteConfigDto.kt
@@ -1,0 +1,9 @@
+package com.wespot.staff.data.config.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RemoteConfigDto(
+    val key: String,
+    val value: String,
+)

--- a/data/src/commonMain/kotlin/com/wespot/staff/data/config/remote/RemoteConfigDataSource.kt
+++ b/data/src/commonMain/kotlin/com/wespot/staff/data/config/remote/RemoteConfigDataSource.kt
@@ -1,18 +1,63 @@
 package com.wespot.staff.data.config.remote
 
+import com.wespot.staff.data.config.model.RemoteConfigDto
+import com.wespot.staff.data.core.safeRequest
 import dev.gitlive.firebase.remoteconfig.FirebaseRemoteConfig
 import dev.gitlive.firebase.remoteconfig.FirebaseRemoteConfigValue
+import io.ktor.client.HttpClient
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpMethod
+import io.ktor.http.path
 
 interface RemoteConfigDataSource {
     suspend fun startRemoteConfig(): Boolean
     fun fetchFromRemoteConfig(): Map<String, FirebaseRemoteConfigValue>
+    suspend fun getRemoteConfigValue(): Result<List<RemoteConfigDto>>
+    suspend fun postRemoteConfigValue(remoteConfig: RemoteConfigDto): Result<Unit>
+    suspend fun putRemoteConfigValue(remoteConfig: RemoteConfigDto): Result<Unit>
+    suspend fun deleteRemoteConfigValue(key: String): Result<Unit>
 }
 
 class DefaultRemoteConfigDataSource(
     private val remoteConfig: FirebaseRemoteConfig,
+    private val httpClient: HttpClient,
 ) : RemoteConfigDataSource {
     override suspend fun startRemoteConfig(): Boolean =
         remoteConfig.fetchAndActivate()
 
     override fun fetchFromRemoteConfig(): Map<String, FirebaseRemoteConfigValue> = remoteConfig.all
+
+    override suspend fun getRemoteConfigValue(): Result<List<RemoteConfigDto>> =
+        httpClient.safeRequest {
+            url {
+                path("/admin/remote-config")
+            }
+            method = HttpMethod.Get
+        }
+
+    override suspend fun postRemoteConfigValue(remoteConfig: RemoteConfigDto): Result<Unit> =
+        httpClient.safeRequest {
+            url {
+                path("/admin/remote-config")
+                setBody(remoteConfig)
+            }
+            method = HttpMethod.Post
+        }
+
+    override suspend fun putRemoteConfigValue(remoteConfig: RemoteConfigDto): Result<Unit> =
+        httpClient.safeRequest {
+            url {
+                path("/admin/remote-config")
+                setBody(remoteConfig)
+            }
+            method = HttpMethod.Put
+        }
+
+    override suspend fun deleteRemoteConfigValue(key: String): Result<Unit> =
+        httpClient.safeRequest {
+            url {
+                path("/admin/remote-config/$key")
+            }
+            method = HttpMethod.Delete
+        }
 }

--- a/designsystem/src/commonMain/kotlin/com/wespot/staff/designsystem/component/WSBottomSheet.kt
+++ b/designsystem/src/commonMain/kotlin/com/wespot/staff/designsystem/component/WSBottomSheet.kt
@@ -1,0 +1,67 @@
+package com.wespot.staff.designsystem.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.wespot.staff.designsystem.theme.StaticTypography
+import com.wespot.staff.designsystem.theme.WeSpotThemeManager
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WSBottomSheet(
+    closeSheet: () -> Unit,
+    sheetState: SheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true,
+    ),
+    content: @Composable () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = closeSheet,
+        sheetState = sheetState,
+        shape = RoundedCornerShape(topStart = 25.dp, topEnd = 25.dp),
+        containerColor = WeSpotThemeManager.colors.bottomSheetColor,
+        dragHandle = null,
+        modifier = Modifier.navigationBarsPadding(),
+    ) {
+        content.invoke()
+    }
+}
+
+@Composable
+fun BottomSheetText(
+    text: String,
+    showDivider: Boolean = true,
+    onClick: () -> Unit,
+) {
+    Text(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(16.dp),
+        text = text,
+        style = StaticTypography().body4,
+        color = Color(0xFFF7F7F8),
+        textAlign = TextAlign.Center,
+    )
+
+    if (showDivider) {
+        HorizontalDivider(
+            modifier = Modifier.fillMaxWidth(),
+            thickness = 1.dp,
+            color = Color(0xFF4F5157),
+        )
+    }
+}

--- a/designsystem/src/commonMain/kotlin/com/wespot/staff/designsystem/component/WSDialog.kt
+++ b/designsystem/src/commonMain/kotlin/com/wespot/staff/designsystem/component/WSDialog.kt
@@ -1,0 +1,147 @@
+package com.wespot.staff.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.wespot.staff.designsystem.theme.StaticTypography
+import com.wespot.staff.designsystem.theme.WeSpotThemeManager
+
+@Composable
+fun WSDialog(
+    dialogType: WSDialogType = WSDialogType.TwoButton,
+    title: String,
+    subTitle: String = "",
+    okButtonText: String = "",
+    cancelButtonText: String = "",
+    textFieldText: String = "",
+    okButtonClick: () -> Unit = {},
+    cancelButtonClick: () -> Unit = {},
+    onTextFieldTextChanged: (String) -> Unit = {},
+    onDismissRequest: () -> Unit,
+) {
+    Dialog(onDismissRequest = onDismissRequest) {
+        Column(
+            modifier = Modifier
+                .clip(WeSpotThemeManager.shapes.medium)
+                .background(WeSpotThemeManager.colors.modalColor)
+                .padding(top = 32.dp, start = 20.dp, end = 20.dp, bottom = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            WSDialogContent(title = title, subTitle = subTitle)
+
+            when (dialogType) {
+                is WSDialogType.TwoButton -> {
+                    WSDialogTwoButton(
+                        okButtonText = okButtonText,
+                        cancelButtonText = cancelButtonText,
+                        okButtonClick = okButtonClick,
+                        cancelButtonClick = cancelButtonClick,
+                    )
+                }
+
+                is WSDialogType.OneButton -> {
+                    WSButton(
+                        text = okButtonText,
+                        onClick = okButtonClick,
+                        buttonType = WSButtonType.Primary,
+                        paddingValues = PaddingValues(0.dp),
+                        content = { it() },
+                    )
+                }
+
+                is WSDialogType.TextField -> {
+                    WSTextField(
+                        value = textFieldText,
+                        onValueChange = onTextFieldTextChanged,
+                        textFieldType = WsTextFieldType.Normal,
+                        placeholder = "",
+                    )
+
+                    WSButton(
+                        text = okButtonText,
+                        onClick = okButtonClick,
+                        buttonType = WSButtonType.Primary,
+                        paddingValues = PaddingValues(0.dp),
+                        content = { it() },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WSDialogContent(
+    title: String,
+    subTitle: String,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = title,
+            style = StaticTypography().header1,
+            color = WeSpotThemeManager.colors.txtTitleColor,
+        )
+
+        if (subTitle.isNotEmpty()) {
+            Text(
+                text = subTitle,
+                style = StaticTypography().body6,
+                color = WeSpotThemeManager.colors.txtSubColor,
+            )
+        }
+    }
+}
+
+@Composable
+private fun WSDialogTwoButton(
+    okButtonText: String,
+    cancelButtonText: String,
+    okButtonClick: () -> Unit,
+    cancelButtonClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Box(modifier = Modifier.weight(1f)) {
+            WSButton(
+                onClick = cancelButtonClick,
+                buttonType = WSButtonType.Secondary,
+                text = cancelButtonText,
+                paddingValues = PaddingValues(0.dp),
+            ) {
+                it()
+            }
+        }
+
+        Box(modifier = Modifier.weight(1f)) {
+            WSButton(
+                onClick = okButtonClick,
+                buttonType = WSButtonType.Primary,
+                text = okButtonText,
+                paddingValues = PaddingValues(0.dp),
+            ) {
+                it()
+            }
+        }
+    }
+}
+
+sealed interface WSDialogType {
+    data object TwoButton : WSDialogType
+    data object OneButton : WSDialogType
+    data object TextField : WSDialogType
+}

--- a/domain/src/commonMain/kotlin/com/wespot/staff/domain/config/RemoteConfig.kt
+++ b/domain/src/commonMain/kotlin/com/wespot/staff/domain/config/RemoteConfig.kt
@@ -1,7 +1,7 @@
 package com.wespot.staff.domain.config
 
 data class RemoteConfig(
-    val key: String,
-    val description: String,
-    val value: String,
+    val key: String = "",
+    val description: String = "",
+    val value: String = "",
 )

--- a/domain/src/commonMain/kotlin/com/wespot/staff/domain/config/RemoteConfigRepository.kt
+++ b/domain/src/commonMain/kotlin/com/wespot/staff/domain/config/RemoteConfigRepository.kt
@@ -3,4 +3,8 @@ package com.wespot.staff.domain.config
 interface RemoteConfigRepository {
     suspend fun startRemoteConfig(): Boolean
     fun fetchFromRemoteConfig(): List<RemoteConfig>
+    suspend fun getRemoteConfigValue(): Result<List<RemoteConfig>>
+    suspend fun postRemoteConfigValue(remoteConfig: RemoteConfig): Result<Unit>
+    suspend fun putRemoteConfigValue(remoteConfig: RemoteConfig): Result<Unit>
+    suspend fun deleteRemoteConfigValue(key: String): Result<Unit>
 }

--- a/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/ConfigurationScreen.kt
+++ b/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/ConfigurationScreen.kt
@@ -1,18 +1,30 @@
 package com.wespot.staff.entire.configuration
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.wespot.staff.common.extensions.collectSideEffect
+import com.wespot.staff.designsystem.component.BottomSheetText
+import com.wespot.staff.designsystem.component.WSBottomSheet
+import com.wespot.staff.designsystem.component.WSDialog
+import com.wespot.staff.designsystem.component.WSDialogType
 import com.wespot.staff.designsystem.component.WSListItem
+import com.wespot.staff.designsystem.component.WSLoadingAnimation
 import com.wespot.staff.designsystem.component.WSTopBar
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -23,8 +35,32 @@ fun ConfigurationScreen(
     viewModel: ConfigurationViewModel = koinViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showEditDialog by remember { mutableStateOf(false) }
+    var showBottomSheet by remember { mutableStateOf(false) }
+
+    viewModel.sideEffect.collectSideEffect {
+        when (it) {
+            is ConfigurationSideEffect.ShowEditConfigurationDialog -> {
+                showEditDialog = true
+            }
+
+            is ConfigurationSideEffect.ShowErrorToast -> {
+                snackbarHostState.showSnackbar(it.message)
+            }
+
+            is ConfigurationSideEffect.ShowToast -> {
+                snackbarHostState.showSnackbar(it.message)
+            }
+
+            ConfigurationSideEffect.ShowBottomSheet -> {
+                showBottomSheet = true
+            }
+        }
+    }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         topBar = {
             WSTopBar(
                 title = "컨피그 값 관리",
@@ -42,7 +78,7 @@ fun ConfigurationScreen(
         ) {
             items(
                 items = state.remoteConfigList,
-                key = { item -> item.key },
+                 key = { item -> item.key },
             ) { item ->
                 /** Description이 비어있으면 key로만 구성한다. */
                 WSListItem(
@@ -52,9 +88,61 @@ fun ConfigurationScreen(
                     } else item.value,
                     selected = false,
                     isMultiLine = true,
-                    onClick = { },
+                    onClick = {
+                        viewModel.selectRemoteConfig(item)
+                    },
                 )
             }
         }
+    }
+
+    if (state.isLoading) {
+        WSLoadingAnimation()
+    }
+
+    if (showBottomSheet) {
+        WSBottomSheet(
+            closeSheet = { showBottomSheet = false },
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 20.dp, vertical = 12.dp)
+            ) {
+                BottomSheetText(
+                    text = "삭제하기",
+                    onClick = {
+                        viewModel.handleDeleteBottomSheetClicked()
+                        showBottomSheet = false
+                    },
+                )
+
+                BottomSheetText(
+                    text = "수정하기",
+                    onClick = {
+                        viewModel.handleEditBottomSheetClicked()
+                        showBottomSheet = false
+                    },
+                    showDivider = false,
+                )
+            }
+        }
+    }
+
+    if (showEditDialog) {
+        WSDialog(
+            dialogType = WSDialogType.TextField,
+            title = state.selectedRemoteConfig.key,
+            subTitle = state.selectedRemoteConfig.description,
+            textFieldText = state.selectedRemoteConfig.value,
+            okButtonText = "수정하기",
+            okButtonClick = {
+                viewModel.editRemoteConfig()
+                showEditDialog = false
+            },
+            onTextFieldTextChanged = viewModel::setRemoteConfigValue,
+            onDismissRequest = {
+                showEditDialog = false
+            },
+        )
     }
 }

--- a/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/ConfigurationSideEffect.kt
+++ b/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/ConfigurationSideEffect.kt
@@ -1,3 +1,8 @@
 package com.wespot.staff.entire.configuration
 
-sealed interface ConfigurationSideEffect
+sealed interface ConfigurationSideEffect {
+    data class ShowErrorToast(val message: String): ConfigurationSideEffect
+    data class ShowToast(val message: String): ConfigurationSideEffect
+    data object ShowEditConfigurationDialog: ConfigurationSideEffect
+    data object ShowBottomSheet: ConfigurationSideEffect
+}

--- a/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/ConfigurationUiState.kt
+++ b/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/ConfigurationUiState.kt
@@ -4,4 +4,6 @@ import com.wespot.staff.domain.config.RemoteConfig
 
 data class ConfigurationUiState(
     val remoteConfigList: List<RemoteConfig> = listOf(),
+    val selectedRemoteConfig: RemoteConfig = RemoteConfig(),
+    val isLoading: Boolean = false,
 )

--- a/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/ConfigurationViewModel.kt
+++ b/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/ConfigurationViewModel.kt
@@ -2,6 +2,7 @@ package com.wespot.staff.entire.configuration
 
 import androidx.lifecycle.viewModelScope
 import com.wespot.staff.common.base.BaseViewModel
+import com.wespot.staff.domain.config.RemoteConfig
 import com.wespot.staff.domain.config.RemoteConfigRepository
 import kotlinx.coroutines.launch
 
@@ -13,14 +14,68 @@ class ConfigurationViewModel(
     }
 
     init {
-        fetchRemoteConfig()
+        getRemoteConfig()
     }
 
-    private fun fetchRemoteConfig() {
+    private fun getRemoteConfig() {
         viewModelScope.launch {
-            reduce {
-                copy(remoteConfigList = remoteConfigRepository.fetchFromRemoteConfig())
-            }
+            reduce { state.copy(isLoading = true) }
+            remoteConfigRepository.getRemoteConfigValue()
+                .onSuccess {
+                    reduce { copy(remoteConfigList = it) }
+                }.onFailure {
+                    postSideEffect(ConfigurationSideEffect.ShowErrorToast("값을 불러오는데 실패하였습니다."))
+                }.also {
+                    reduce { state.copy(isLoading = false) }
+                }
+        }
+    }
+
+    fun selectRemoteConfig(remoteConfig: RemoteConfig) {
+        reduce {
+            state.copy(selectedRemoteConfig = remoteConfig)
+        }
+        postSideEffect(ConfigurationSideEffect.ShowBottomSheet)
+    }
+
+    fun handleDeleteBottomSheetClicked() {
+        viewModelScope.launch {
+            reduce { state.copy(isLoading = true) }
+            remoteConfigRepository.deleteRemoteConfigValue(state.selectedRemoteConfig.key)
+                .onSuccess {
+                    getRemoteConfig()
+                    postSideEffect(ConfigurationSideEffect.ShowToast("삭제 완료"))
+                }
+                .onFailure {
+                    postSideEffect(ConfigurationSideEffect.ShowErrorToast("알 수 없는 에러가 발생했습니다. ${it.message.toString()}"))
+                }.also {
+                    reduce { state.copy(isLoading = false) }
+                }
+        }
+    }
+
+    fun handleEditBottomSheetClicked() {
+        postSideEffect(ConfigurationSideEffect.ShowEditConfigurationDialog)
+    }
+
+    fun setRemoteConfigValue(value: String) {
+        reduce {
+            state.copy(selectedRemoteConfig = state.selectedRemoteConfig.copy(value = value))
+        }
+    }
+
+    fun editRemoteConfig() {
+        reduce { state.copy(isLoading = true) }
+        viewModelScope.launch {
+            remoteConfigRepository.putRemoteConfigValue(remoteConfig = state.selectedRemoteConfig)
+                .onSuccess {
+                    postSideEffect(ConfigurationSideEffect.ShowToast("수정 완료"))
+                    getRemoteConfig()
+                }.onFailure {
+                    postSideEffect(ConfigurationSideEffect.ShowErrorToast("알 수 없는 에러가 발생했습니다. ${it.message.toString()}"))
+                }.also {
+                    reduce { state.copy(isLoading = false) }
+                }
         }
     }
 }

--- a/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/add/ConfigurationAddComponent.kt
+++ b/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/add/ConfigurationAddComponent.kt
@@ -1,0 +1,13 @@
+package com.wespot.staff.entire.configuration.add
+
+import com.arkivanov.decompose.ComponentContext
+
+class ConfigurationAddComponent(
+    componentContext: ComponentContext,
+    private val popBackStack: () -> Unit,
+    private val navigateToHome: (String) -> Unit,
+): ComponentContext by componentContext {
+    fun navigateUp() = popBackStack()
+
+    fun navigateToHomeScreen(toastMessage: String) = navigateToHome(toastMessage)
+}

--- a/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/add/ConfigurationAddScreen.kt
+++ b/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/add/ConfigurationAddScreen.kt
@@ -1,0 +1,151 @@
+package com.wespot.staff.entire.configuration.add
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.wespot.staff.common.extensions.clickableSingle
+import com.wespot.staff.common.extensions.collectSideEffect
+import com.wespot.staff.designsystem.component.WSButton
+import com.wespot.staff.designsystem.component.WSLoadingAnimation
+import com.wespot.staff.designsystem.component.WSTextField
+import com.wespot.staff.designsystem.component.WSTopBar
+import com.wespot.staff.designsystem.component.WsTextFieldType
+import com.wespot.staff.designsystem.theme.StaticTypography
+import com.wespot.staff.designsystem.theme.WeSpotThemeManager
+import org.koin.compose.viewmodel.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ConfigurationAddScreen(
+    component: ConfigurationAddComponent,
+    viewModel: ConfigurationAddViewModel = koinViewModel(),
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    viewModel.sideEffect.collectSideEffect {
+        when (it) {
+            ConfigurationAddSideEffect.NavigateToHomeScreen -> {
+                component.navigateToHomeScreen("등록 완료")
+            }
+
+            is ConfigurationAddSideEffect.ShowErrorToast -> {
+                snackbarHostState.showSnackbar(it.message)
+            }
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+        topBar = {
+            WSTopBar(
+                title = "",
+                canNavigateBack = true,
+                navigateUp = component::navigateUp,
+            )
+        },
+        modifier = Modifier
+            .fillMaxSize()
+            .clickableSingle {
+                keyboardController?.hide()
+            },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 20.dp)
+                    .weight(1f)
+            ) {
+                Text(
+                    text = "컨피그 값 생성",
+                    style = StaticTypography().header1,
+                    color = WeSpotThemeManager.colors.txtTitleColor,
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "Key는 공백 없이 대문자와 언더바로 구성해주세요.",
+                    style = StaticTypography().body6,
+                    color = WeSpotThemeManager.colors.txtSubColor,
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                EditTextField(
+                    title = "컨피그 값 Key",
+                    value = state.remoteConfigKey,
+                    placeHolder = "컨피그 값 Key를 입력하세요",
+                    onValueChange = viewModel::setRemoteConfigKey,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                EditTextField(
+                    title = "컨피그 값 Value",
+                    value = state.remoteConfigValue,
+                    placeHolder = "컨피그 값 Value를 입력하세요",
+                    isBody = true,
+                    onValueChange = viewModel::setRemoteConfigValue,
+                )
+            }
+
+            WSButton(
+                text = "컨피그 값 등록하기",
+                onClick = viewModel::postRemoteConfig,
+                content = { it() },
+                enabled = state.remoteConfigKey.isNotBlank() && state.remoteConfigValue.isNotBlank()
+            )
+        }
+    }
+
+    if (state.isLoading) {
+        WSLoadingAnimation()
+    }
+}
+
+@Composable
+private fun EditTextField(
+    title: String,
+    value: String,
+    placeHolder: String,
+    isBody: Boolean = false,
+    onValueChange: (String) -> Unit,
+) {
+    Column {
+        Text(
+            modifier = Modifier.padding(bottom = 12.dp),
+            text = title,
+            style = StaticTypography().body4,
+        )
+
+        WSTextField(
+            value = value,
+            placeholder = placeHolder,
+            onValueChange = onValueChange,
+            textFieldType = if (isBody) WsTextFieldType.Message else WsTextFieldType.Normal
+        )
+    }
+}

--- a/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/add/ConfigurationAddSideEffect.kt
+++ b/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/add/ConfigurationAddSideEffect.kt
@@ -1,0 +1,7 @@
+package com.wespot.staff.entire.configuration.add
+
+
+sealed interface ConfigurationAddSideEffect {
+    data class ShowErrorToast(val message: String): ConfigurationAddSideEffect
+    data object NavigateToHomeScreen: ConfigurationAddSideEffect
+}

--- a/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/add/ConfigurationAddUiState.kt
+++ b/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/add/ConfigurationAddUiState.kt
@@ -1,0 +1,7 @@
+package com.wespot.staff.entire.configuration.add
+
+data class ConfigurationAddUiState(
+    val remoteConfigKey: String = "",
+    val remoteConfigValue: String = "",
+    val isLoading: Boolean = false,
+)

--- a/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/add/ConfigurationAddViewModel.kt
+++ b/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/configuration/add/ConfigurationAddViewModel.kt
@@ -1,0 +1,42 @@
+package com.wespot.staff.entire.configuration.add
+
+import androidx.lifecycle.viewModelScope
+import com.wespot.staff.common.base.BaseViewModel
+import com.wespot.staff.domain.config.RemoteConfig
+import com.wespot.staff.domain.config.RemoteConfigRepository
+import kotlinx.coroutines.launch
+
+class ConfigurationAddViewModel(
+    private val remoteConfigRepository: RemoteConfigRepository
+): BaseViewModel<ConfigurationAddUiState, ConfigurationAddSideEffect>() {
+    override fun createInitialState(): ConfigurationAddUiState {
+        return ConfigurationAddUiState()
+    }
+
+    fun setRemoteConfigKey(key: String) {
+        reduce {
+            copy(remoteConfigKey = key)
+        }
+    }
+
+    fun setRemoteConfigValue(value: String) {
+        reduce {
+            copy(remoteConfigValue = value)
+        }
+    }
+
+    fun postRemoteConfig() {
+        reduce { state.copy(isLoading = true) }
+        val key = state.remoteConfigKey.trim().replace(" ", "_")
+        viewModelScope.launch {
+            remoteConfigRepository.postRemoteConfigValue(remoteConfig = RemoteConfig(key = key, value = state.remoteConfigValue))
+                .onSuccess {
+                    postSideEffect(ConfigurationAddSideEffect.NavigateToHomeScreen)
+                }.onFailure {
+                    postSideEffect(ConfigurationAddSideEffect.ShowErrorToast("알 수 없는 에러가 발생했습니다. ${it.message.toString()}"))
+                }.also {
+                    reduce { state.copy(isLoading = false) }
+                }
+        }
+    }
+}

--- a/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/home/EntireHomeComponent.kt
+++ b/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/home/EntireHomeComponent.kt
@@ -7,8 +7,11 @@ class EntireHomeComponent(
     val toastMessage: String? = null,
     private val navigateToConfiguration: () -> Unit,
     private val navigateToNotification: () -> Unit,
+    private val navigateToAddConfiguration: () -> Unit,
 ): ComponentContext by componentContext {
     fun navigateToConfigurationScreen() = navigateToConfiguration()
+
+    fun navigateToAddConfigurationScreen() = navigateToAddConfiguration()
 
     fun navigateToNotificationScreen() = navigateToNotification()
 }

--- a/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/home/EntireHomeScreen.kt
+++ b/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/home/EntireHomeScreen.kt
@@ -45,6 +45,11 @@ fun EntireHomeScreen(component: EntireHomeComponent) {
                 onClick = component::navigateToConfigurationScreen
             )
 
+            WSNavigationListItem(
+                text = "컨피그 값 등록",
+                onClick = component::navigateToAddConfigurationScreen
+            )
+
             HorizontalDivider(
                 modifier = Modifier.fillMaxWidth(),
                 thickness = 1.dp,

--- a/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/navigation/EntireNavigation.kt
+++ b/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/navigation/EntireNavigation.kt
@@ -7,6 +7,7 @@ import com.arkivanov.decompose.extensions.compose.stack.animation.fade
 import com.arkivanov.decompose.extensions.compose.stack.animation.stackAnimation
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.wespot.staff.entire.configuration.ConfigurationScreen
+import com.wespot.staff.entire.configuration.add.ConfigurationAddScreen
 import com.wespot.staff.entire.home.EntireHomeScreen
 import com.wespot.staff.entire.navigation.EntireRootComponent.EntireChild
 import com.wespot.staff.entire.notification.NotificationScreen
@@ -21,6 +22,7 @@ fun EntireNavigation(component: EntireRootComponent) {
         when (val child = it.instance) {
             is EntireChild.EntireHomeScreen -> EntireHomeScreen(child.component)
             is EntireChild.ConfigurationScreen -> ConfigurationScreen(child.component)
+            is EntireChild.ConfigurationAddScreen -> ConfigurationAddScreen(child.component)
             is EntireChild.NotificationScreen -> NotificationScreen(child.component)
         }
     }

--- a/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/navigation/EntireRootComponent.kt
+++ b/feature-entire/src/commonMain/kotlin/com/wespot/staff/entire/navigation/EntireRootComponent.kt
@@ -5,9 +5,10 @@ import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.router.stack.StackNavigation
 import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.pop
-import com.arkivanov.decompose.router.stack.pushToFront
 import com.arkivanov.decompose.value.Value
+import com.wespot.staff.common.extensions.navigate
 import com.wespot.staff.entire.configuration.ConfigurationComponent
+import com.wespot.staff.entire.configuration.add.ConfigurationAddComponent
 import com.wespot.staff.entire.home.EntireHomeComponent
 import com.wespot.staff.entire.navigation.EntireRootComponent.EntireChild
 import com.wespot.staff.entire.notification.NotificationComponent
@@ -23,6 +24,7 @@ interface EntireRootComponent {
     sealed class EntireChild {
         class EntireHomeScreen(val component: EntireHomeComponent) : EntireChild()
         class ConfigurationScreen(val component: ConfigurationComponent) : EntireChild()
+        class ConfigurationAddScreen(val component: ConfigurationAddComponent) : EntireChild()
         class NotificationScreen(val component: NotificationComponent) : EntireChild()
     }
 }
@@ -53,6 +55,7 @@ class DefaultEntireRootComponent(
             is EntireConfiguration.EntireHome -> EntireChild.EntireHomeScreen(entireHomeComponent(componentContext, config))
             is EntireConfiguration.Configuration -> EntireChild.ConfigurationScreen(configurationComponent(componentContext))
             is EntireConfiguration.Notification -> EntireChild.NotificationScreen(notificationComponent(componentContext))
+            is EntireConfiguration.ConfigurationAdd -> EntireChild.ConfigurationAddScreen(configurationAddComponent(componentContext))
         }
 
     private fun entireHomeComponent(componentContext: ComponentContext, config: EntireConfiguration.EntireHome) =
@@ -60,11 +63,14 @@ class DefaultEntireRootComponent(
             componentContext = componentContext,
             toastMessage = config.toastMessage,
             navigateToNotification = {
-                navigation.pushToFront(EntireConfiguration.Notification)
+                navigation.navigate(EntireConfiguration.Notification)
             },
             navigateToConfiguration = {
-                navigation.pushToFront(EntireConfiguration.Configuration)
-            }
+                navigation.navigate(EntireConfiguration.Configuration)
+            },
+            navigateToAddConfiguration = {
+                navigation.navigate(EntireConfiguration.ConfigurationAdd)
+            },
         )
 
     private fun configurationComponent(componentContext: ComponentContext) =
@@ -73,12 +79,21 @@ class DefaultEntireRootComponent(
             popBackStack = ::popBackStack,
         )
 
+    private fun configurationAddComponent(componentContext: ComponentContext) =
+        ConfigurationAddComponent(
+            componentContext = componentContext,
+            popBackStack = ::popBackStack,
+            navigateToHome = {
+                navigation.navigate(EntireConfiguration.EntireHome(it))
+            },
+        )
+
     private fun notificationComponent(componentContext: ComponentContext) =
         NotificationComponent(
             componentContext = componentContext,
             popBackStack = ::popBackStack,
             navigateToHome = {
-                navigation.pushToFront(EntireConfiguration.EntireHome(it))
+                navigation.navigate(EntireConfiguration.EntireHome(it))
             },
         )
 
@@ -92,5 +107,8 @@ class DefaultEntireRootComponent(
 
         @Serializable
         data object Notification : EntireConfiguration
+
+        @Serializable
+        data object ConfigurationAdd : EntireConfiguration
     }
 }

--- a/feature-vote/src/commonMain/kotlin/com/wespot/staff/vote/navigation/VoteRootComponent.kt
+++ b/feature-vote/src/commonMain/kotlin/com/wespot/staff/vote/navigation/VoteRootComponent.kt
@@ -5,8 +5,8 @@ import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.router.stack.StackNavigation
 import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.pop
-import com.arkivanov.decompose.router.stack.pushToFront
 import com.arkivanov.decompose.value.Value
+import com.wespot.staff.common.extensions.navigate
 import com.wespot.staff.domain.vote.VoteQuestionContent
 import com.wespot.staff.vote.write.QuestionWriteComponent
 import com.wespot.staff.vote.home.VoteHomeComponent
@@ -64,10 +64,10 @@ class DefaultVoteRootComponent(
         VoteHomeComponent(
             componentContext = componentContext,
             navigateToQuestion = {
-                navigation.pushToFront(VoteConfiguration.Question())
+                navigation.navigate(VoteConfiguration.Question())
             },
             navigateToQuestionWrite = {
-                navigation.pushToFront(VoteConfiguration.QuestionWrite)
+                navigation.navigate(VoteConfiguration.QuestionWrite)
             }
         )
 
@@ -82,13 +82,13 @@ class DefaultVoteRootComponent(
             componentContext = componentContext,
             popBackStack = ::popBackStack,
             navigateToQuestionConfirm = {
-                navigation.pushToFront(
+                navigation.navigate(
                     VoteConfiguration.QuestionConfirm(
                         it
                     )
                 )
             },
-            navigateToQuestion = { navigation.pushToFront(VoteConfiguration.Question(it)) },
+            navigateToQuestion = { navigation.navigate(VoteConfiguration.Question(it)) },
         )
 
     private fun questionConfirmComponent(
@@ -99,7 +99,7 @@ class DefaultVoteRootComponent(
             componentContext = componentContext,
             questionList = config.questionList,
             popBackStack = ::popBackStack,
-            navigateToQuestion = { navigation.pushToFront(VoteConfiguration.Question(it)) },
+            navigateToQuestion = { navigation.navigate(VoteConfiguration.Question(it)) },
         )
 
     @Serializable

--- a/feature-vote/src/commonMain/kotlin/com/wespot/staff/vote/write/QuestionWriteScreen.kt
+++ b/feature-vote/src/commonMain/kotlin/com/wespot/staff/vote/write/QuestionWriteScreen.kt
@@ -100,5 +100,5 @@ fun QuestionWriteScreen(
     }
 }
 
-const val QUESTION_ADD_SCREEN_INDEX = 0
-const val QUESTION_PARSE_SCREEN_INDEX = 1
+private const val QUESTION_ADD_SCREEN_INDEX = 0
+private const val QUESTION_PARSE_SCREEN_INDEX = 1

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.3</string>
+	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#20 RemoteConfig 수정 조회 삭제 기능 구현 

## 2. 🔥 변경된 점

기존 RemoteConfig에서 직접 받아오던 로직을, 서버에서 받아오도록 수정했습니다. 

서버를 통해 삭제 / 조회 / 추가 기능을 구현했습니다. 

## 3. ✅ 필수 체크 사항 
## 4. 📸 작업물 사진 공유(선택)

<img width="351" alt="image" src="https://github.com/user-attachments/assets/29b7d99b-cdab-41ab-bf90-9c136a26455d" />
<img width="356" alt="image" src="https://github.com/user-attachments/assets/3c8f61bc-ab7d-4032-8b82-1d3fd6011844" />
<img width="368" alt="image" src="https://github.com/user-attachments/assets/1a2a68cf-519e-4307-96a6-63f8c860b7e1" />
<img width="367" alt="image" src="https://github.com/user-attachments/assets/705d9bac-2e21-4c61-849d-e7fb29601a30" />


## 5. 💡알게된 혹은 궁금한 사항